### PR TITLE
Tom/7230 Updated bootstrap backend to 5.25.0 + Copyright year change

### DIFF
--- a/app/uk/gov/hmrc/helptosavestub/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helptosavestub/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/BARSController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/BARSController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/BankDetailsBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/BankDetailsBehaviour.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/DESController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/DESController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/DESThresholdController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/DESThresholdController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/DWPController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/DWPController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/DWPEligibilityBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/DWPEligibilityBehaviour.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/EligibilityCheckController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/EligibilityCheckController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/EmailVerificationController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/EmailVerificationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/ITMPEnrolmentController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/ITMPEnrolmentController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/NSIController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/NSIController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/NSIGetAccountBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/NSIGetAccountBehaviour.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/NSIGetTransactionsBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/NSIGetTransactionsBehaviour.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/PayePersonalDetailsController.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/PayePersonalDetailsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/controllers/package.scala
+++ b/app/uk/gov/hmrc/helptosavestub/controllers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/models/BankDetails.scala
+++ b/app/uk/gov/hmrc/helptosavestub/models/BankDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/models/ContactPreference.scala
+++ b/app/uk/gov/hmrc/helptosavestub/models/ContactPreference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/models/NSIErrorResponse.scala
+++ b/app/uk/gov/hmrc/helptosavestub/models/NSIErrorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/models/NSIPayload.scala
+++ b/app/uk/gov/hmrc/helptosavestub/models/NSIPayload.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/util/Delays.scala
+++ b/app/uk/gov/hmrc/helptosavestub/util/Delays.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/util/ErrorJson.scala
+++ b/app/uk/gov/hmrc/helptosavestub/util/ErrorJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/util/Logging.scala
+++ b/app/uk/gov/hmrc/helptosavestub/util/Logging.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helptosavestub/util/package.scala
+++ b/app/uk/gov/hmrc/helptosavestub/util/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -79,11 +79,12 @@ lazy val microservice =
     .settings(scalacOptions += "-P:silencer:pathFilters=routes")
     .settings(Global / lintUnusedKeysOnLoad := false)
 
-val appName = "help-to-save-stub"
-val hmrc    = "uk.gov.hmrc"
+val appName                 = "help-to-save-stub"
+val hmrc                    = "uk.gov.hmrc"
+val bootstrapBackendVersion = "5.25.0"
 val dependencies = Seq(
   ws,
-  hmrc                %% "bootstrap-backend-play-28" % "5.14.0",
+  hmrc                %% "bootstrap-backend-play-28" % bootstrapBackendVersion,
   hmrc                %% "domain"                    % "6.2.0-play-28",
   hmrc                %% "stub-data-generator"       % "0.5.3",
   "org.scalacheck"    %% "scalacheck"                % "1.14.3",
@@ -96,13 +97,13 @@ val dependencies = Seq(
 )
 
 def testDependencies(scope: String = "test") = Seq(
-  hmrc                     %% "bootstrap-backend-play-28" % "5.14.0"            % scope,
-  hmrc                     %% "service-integration-test"  % "1.1.0-play-28"     % scope,
-  "org.scalatest"          %% "scalatest"                 % "3.2.9"             % scope,
-  "com.vladsch.flexmark"   % "flexmark-all"               % "0.35.10"           % scope,
-  "org.scalatestplus"      %% "scalatestplus-scalacheck"  % "3.1.0.0-RC2"       % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play"        % "5.1.0"             % scope,
-  "com.typesafe.play"      %% "play-test"                 % PlayVersion.current % scope,
-  "com.miguno.akka"        %% "akka-mock-scheduler"       % "0.5.5"             % scope,
-  "org.pegdown"            % "pegdown"                    % "1.6.0"             % scope
+  hmrc                     %% "bootstrap-backend-play-28" % bootstrapBackendVersion % scope,
+  hmrc                     %% "service-integration-test"  % "1.1.0-play-28"         % scope,
+  "org.scalatest"          %% "scalatest"                 % "3.2.9"                 % scope,
+  "com.vladsch.flexmark"   % "flexmark-all"               % "0.35.10"               % scope,
+  "org.scalatestplus"      %% "scalatestplus-scalacheck"  % "3.1.0.0-RC2"           % scope,
+  "org.scalatestplus.play" %% "scalatestplus-play"        % "5.1.0"                 % scope,
+  "com.typesafe.play"      %% "play-test"                 % PlayVersion.current     % scope,
+  "com.miguno.akka"        %% "akka-mock-scheduler"       % "0.5.5"                 % scope,
+  "org.pegdown"            % "pegdown"                    % "1.6.0"                 % scope
 )

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,9 +5,7 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="INFO"/>
-
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/BARSControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/BARSControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/DESThresholdControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/DESThresholdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/DWPControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/DWPControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/EligibilityCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/EligibilityCheckControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/NSIControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/NSIControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/PayePersonalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/PayePersonalDetailsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/TestSupport.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/TestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/controllers/support/AkkaMaterializerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/controllers/support/AkkaMaterializerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/util/DelaysSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/util/DelaysSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helptosavestub/util/UnitSpec.scala
+++ b/test/uk/gov/hmrc/helptosavestub/util/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Bootstrap bump + updated copyright year 2022 -> 2023.
[Ticket](https://jira.tools.tax.service.gov.uk/browse/DLS-7230)