### PR TITLE
DLS-9954 | Fix service start issue

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,7 @@ object AppDependencies {
     hmrc                %% s"domain-$playVersion"            % "9.0.0",
     hmrc                %% "stub-data-generator"             % "1.1.0",
     "org.typelevel"     %% "cats-core"                       % "2.10.0",
-    "ai.x"              %% "play-json-extensions"            % "0.42.0",
+    "ai.x"              %% "play-json-extensions"            % "0.42.0" exclude ("com.typesafe.play", "play-json_2.13"),
     "com.github.kxbmap" %% "configs"                         % "0.6.1"
   )
 


### PR DESCRIPTION
Stub is failing to start in SM due to following exception
```java.lang.NoSuchMethodError: 'play.api.libs.json.OWrites play.api.libs.json.JsObject$.writes()'```

This is due to an old version of play-json pulled in as transitive dependency from `ai.x.play-json-extensions`. 
Excluding that so that it doesn't conflict, but in generally should not be included due to play-json already defined at project level via `org.playframework` sbt-plugin. 